### PR TITLE
Added a section about resolving meteor issues on macOS Monterey

### DIFF
--- a/getting-started/setup/README.md
+++ b/getting-started/setup/README.md
@@ -25,3 +25,24 @@ _If you are a Windows user and get stuck at any point in the development process
 
 {% page-ref page="windows-instructions.md" %}
 
+### **A note about macOS Monterey (Apple M1 Chip) Setup**
+
+When using apple's new M1 chip, the minimum Meteor version that you can install is version 2.5.1. This causes an issue with Empirica which uses a specific version of Meteor (1.10.2) as shown below.
+
+```
+This project uses Meteor 1.10.2, which isn't available on this platform. To work with this app on all supported platforms, use meteor update --release METEOR@2.7.3 to pin this app to the newest compatible release.
+```
+
+**Do not run the recommended command to update meteor as that would also cause issues.**
+
+To resolve this issue, you need to switch from macOS Monterey to macOS Rosetta by running the following command:
+
+```
+arch -x86_64 zsh
+```
+
+Once entered, run the following command to change the meteor version to 1.10.2.
+
+```
+meteor update --release 1.10.2
+```


### PR DESCRIPTION
macOS Monterey installs a minimum meteor version that conflicts with the default meteor version that Empirica uses. I added a small note in the setup page to address this issue.